### PR TITLE
Fix username display bug

### DIFF
--- a/lib/habit_tracker_screen.dart
+++ b/lib/habit_tracker_screen.dart
@@ -18,6 +18,7 @@ class _HabitTrackerScreenState extends State<HabitTrackerScreen> {
   @override
   void initState() {
     super.initState();
+    name = widget.username;
   }
 
   Future<void> _saveHabits() async {


### PR DESCRIPTION
## Summary
- ensure the habit tracker screen uses the username from LoginScreen

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68469a2f4d20832b82aa1a25a221bb54