### PR TITLE
Fetch countries from API

### DIFF
--- a/lib/country_list.dart
+++ b/lib/country_list.dart
@@ -1,4 +1,9 @@
-const List<String> countryList = [
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Default list used when the API request fails.
+const List<String> fallbackCountries = [
   'United States',
   'Canada',
   'United Kingdom',
@@ -10,3 +15,30 @@ const List<String> countryList = [
   'Brazil',
   'South Africa',
 ];
+
+/// Fetches country names from the REST Countries API.
+Future<List<String>> fetchCountryList() async {
+  final uri = Uri.parse('https://restcountries.com/v3.1/all?fields=name');
+  final response = await http.get(uri);
+  if (response.statusCode == 200) {
+    final data = jsonDecode(response.body) as List<dynamic>;
+    final names = data
+        .map((country) => country['name'])
+        .whereType<Map>()
+        .map((name) => name['common'] as String)
+        .toList();
+    names.sort();
+    return names;
+  } else {
+    throw Exception('Failed to load countries');
+  }
+}
+
+/// Returns the fetched list or [fallbackCountries] on error.
+Future<List<String>> getCountries() async {
+  try {
+    return await fetchCountryList();
+  } catch (_) {
+    return fallbackCountries;
+  }
+}

--- a/lib/register_screen.dart
+++ b/lib/register_screen.dart
@@ -99,11 +99,12 @@ class _RegisterScreenState extends State<RegisterScreen> {
                 keyboardType: TextInputType.number,
               ),
               countryList.isEmpty
-                  ? const CircularProgressIndicator()
+                  ? const Center(child: CircularProgressIndicator())
                   : DropdownButtonFormField<String>(
                       value: selectedCountry,
                       decoration:
                           const InputDecoration(labelText: 'Country'),
+                      isExpanded: true,
                       items: countryList
                           .map((c) => DropdownMenuItem(
                                 value: c,

--- a/lib/register_screen.dart
+++ b/lib/register_screen.dart
@@ -17,7 +17,22 @@ class _RegisterScreenState extends State<RegisterScreen> {
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
 
-  String selectedCountry = countryList.first;
+  List<String> countryList = [];
+  String selectedCountry = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCountries();
+  }
+
+  Future<void> _loadCountries() async {
+    final countries = await getCountries();
+    setState(() {
+      countryList = countries;
+      selectedCountry = countries.isNotEmpty ? countries.first : '';
+    });
+  }
 
   final Map<String, bool> _habitToggles = {
     'Exercise': false,
@@ -83,18 +98,24 @@ class _RegisterScreenState extends State<RegisterScreen> {
                 decoration: InputDecoration(labelText: 'Age'),
                 keyboardType: TextInputType.number,
               ),
-              DropdownButtonFormField<String>(
-                value: selectedCountry,
-                decoration: InputDecoration(labelText: 'Country'),
-                items: countryList
-                    .map((c) => DropdownMenuItem(value: c, child: Text(c)))
-                    .toList(),
-                onChanged: (val) {
-                  setState(() {
-                    selectedCountry = val!;
-                  });
-                },
-              ),
+              countryList.isEmpty
+                  ? const CircularProgressIndicator()
+                  : DropdownButtonFormField<String>(
+                      value: selectedCountry,
+                      decoration:
+                          const InputDecoration(labelText: 'Country'),
+                      items: countryList
+                          .map((c) => DropdownMenuItem(
+                                value: c,
+                                child: Text(c),
+                              ))
+                          .toList(),
+                      onChanged: (val) {
+                        setState(() {
+                          selectedCountry = val ?? '';
+                        });
+                      },
+                    ),
               TextField(
                 controller: emailController,
                 decoration: InputDecoration(labelText: 'Email'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `http` dependency
- replace static country list with REST Countries API fetcher
- load countries on registration screen
- show fallback if API fails

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4847c2b4832b907f1e4099d20e94